### PR TITLE
Change MorseCode enum to enum class

### DIFF
--- a/Project/Morse Key/include/MorseManager.h
+++ b/Project/Morse Key/include/MorseManager.h
@@ -1,7 +1,7 @@
 #ifndef MORSE_MANAGER_H
 #define MORSE_MANAGER_H
 
-enum MorseCode {
+enum class MorseCode {
     NONE,
     DOT,
     DASH

--- a/Project/Morse Key/src/MorseManager.cpp
+++ b/Project/Morse Key/src/MorseManager.cpp
@@ -6,7 +6,7 @@ MorseManager::MorseManager(){
     _buttonPressed = false;
     _buttonDownTime = 0;
     _buttonUpTime = 0;
-    _lastInput = NONE;
+    _lastInput = MorseCode::NONE;
 }
 
 bool MorseManager::IsButtonPressed(){
@@ -32,9 +32,9 @@ void MorseManager::ButtonRelease()
     Serial.println(String("Press duration: ") + pressDuration);
     
     if (pressDuration > DOT_LIMIT){
-        _lastInput = DASH;
+        _lastInput = MorseCode::DASH;
     }else{
-        _lastInput = DOT;
+        _lastInput = MorseCode::DOT;
     }
 }
 

--- a/Project/Morse Key/src/main.cpp
+++ b/Project/Morse Key/src/main.cpp
@@ -33,13 +33,13 @@ void loop() {
 void PrintInput(){
   MorseCode symbol = morseManager.getLastInput();
   switch (symbol){
-    case DOT: 
+    case MorseCode::DOT: 
       Serial.println("DOT");
       break;
-    case DASH: 
+    case MorseCode::DASH: 
       Serial.println("DASH");
       break;
-    case NONE: 
+    case MorseCode::NONE: 
       Serial.println("Uh oh!");
       break;
   }


### PR DESCRIPTION
Usage of the enum values changes from "DASH" to "MorseCode::DASH".

Closes #2 